### PR TITLE
Add assignee_email to Todos, and rename checked field

### DIFF
--- a/todos/todo_model.py
+++ b/todos/todo_model.py
@@ -15,9 +15,10 @@ class TodoModel(Model):
 
     todo_id = UnicodeAttribute(hash_key=True, null=False)
     text = UnicodeAttribute(null=False)
-    checked = BooleanAttribute(null=False)
+    is_checked = BooleanAttribute(null=False)
     createdAt = UTCDateTimeAttribute(null=False, default=datetime.now())
     updatedAt = UTCDateTimeAttribute(null=False)
+    assignee_email = UnicodeAttribute(null=False)
 
     def save(self, conditional_operator=None, **expected_values):
         self.updatedAt = datetime.now()


### PR DESCRIPTION
Start collecting the emails of assignees so that tasks can be assigned to people
Rename `checked` to `is_checked` to align with standards